### PR TITLE
Replace log with logrus

### DIFF
--- a/internal/provider/logging_transport.go
+++ b/internal/provider/logging_transport.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/internal/provider/provider_config.go
+++ b/internal/provider/provider_config.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 
 	"github.com/hashicorp/go-cleanhttp"

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"testing"

--- a/internal/provider/resource_chrome_policy.go
+++ b/internal/provider/resource_chrome_policy.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/internal/provider/resource_domain.go
+++ b/internal/provider/resource_domain.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_domain_alias.go
+++ b/internal/provider/resource_domain_alias.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/provider/resource_domain_alias_sweeper_test.go
+++ b/internal/provider/resource_domain_alias_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_domain_sweeper_test.go
+++ b/internal/provider/resource_domain_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_gmail_send_as_alias.go
+++ b/internal/provider/resource_gmail_send_as_alias.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/resource_group_member.go
+++ b/internal/provider/resource_group_member.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_group_members.go
+++ b/internal/provider/resource_group_members.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/internal/provider/resource_group_settings.go
+++ b/internal/provider/resource_group_settings.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/internal/provider/resource_group_sweeper_test.go
+++ b/internal/provider/resource_group_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_org_unit.go
+++ b/internal/provider/resource_org_unit.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	directory "google.golang.org/api/admin/directory/v1"
 	"google.golang.org/api/googleapi"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func resourceOrgUnit() *schema.Resource {

--- a/internal/provider/resource_org_unit_sweeper_test.go
+++ b/internal/provider/resource_org_unit_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/go-cty/cty"

--- a/internal/provider/resource_role_assignment.go
+++ b/internal/provider/resource_role_assignment.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/internal/provider/resource_role_sweeper_test.go
+++ b/internal/provider/resource_role_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/internal/provider/resource_schema_sweeper_test.go
+++ b/internal/provider/resource_schema_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/mail"
 	"reflect"
 	"strconv"

--- a/internal/provider/resource_user_sweeper_test.go
+++ b/internal/provider/resource_user_sweeper_test.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )

--- a/internal/provider/retry_predicates.go
+++ b/internal/provider/retry_predicates.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/internal/provider/retry_transport.go
+++ b/internal/provider/retry_transport.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"google.golang.org/api/googleapi"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"time"

--- a/internal/provider/retry_utils.go
+++ b/internal/provider/retry_utils.go
@@ -5,7 +5,7 @@ package googleworkspace
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"time"
 

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -4,7 +4,7 @@
 package googleworkspace
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -6,7 +6,7 @@ package googleworkspace
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/mail"
 	"os"
 	"reflect"

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-provider-googleworkspace/internal/provider"


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-googleworkspace', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
examples
templates
.release
scripts
.github
docs
internal
tools
.git
.vscode
provider
data-sources
resources
googleworkspace_users
googleworkspace_privileges
googleworkspace_group_settings
googleworkspace_group_member
googleworkspace_domain
googleworkspace_schema
googleworkspace_user
googleworkspace_group
googleworkspace_chrome_policy_schema
googleworkspace_org_unit
googleworkspace_groups
googleworkspace_role
googleworkspace_group_members
googleworkspace_domain_alias
googleworkspace_group_settings
googleworkspace_group_member
googleworkspace_domain
googleworkspace_schema
googleworkspace_user
googleworkspace_gmail_send_as_alias
googleworkspace_group
googleworkspace_chrome_policy
googleworkspace_org_unit
googleworkspace_role
googleworkspace_group_members
googleworkspace_role_assignment
googleworkspace_domain_alias
guides
vault
workflows
infra
data-sources
resources
guides
provider
test-data
objects
info
branches
logs
refs
hooks
1b
8d
20
9f
24
4e
6e
78
e6
b0
49
fe
01
57
1e
e4
f5
1c
44
95
dc
12
b7
ee
c8
1f
5c
7c
07
fa
87
81
9e
52
8e
d6
96
ba
29
02
ac
3f
71
4a
ec
0e
69
42
9c
a3
6c
db
dd
76
43
3e
34
60
1d
4c
26
a4
21
d2
19
fd
9b
a0
c2
f3
fb
b4
cb
0b
c1
a6
0f
74
93
61
5b
cf
d1
c7
de
2a
f6
e9
pack
ef
9a
da
d7
b3
ce
3a
b5
f1
28
info
f8
80
e5
ed
a7
3c
9d
15
56
c6
2b
fc
2e
d4
98
73
7e
46
88
0c
c0
af
a8
5e
35
40
ab
e1
00
37
83
4f
d3
0d
2f
8f
d9
39
17
77
c4
f9
04
8a
64
b2
7b
48
cd
14
5d
bb
2d
5f
45
f4
03
a1
25
86
df
4d
0a
13
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)